### PR TITLE
Use conventional model name in build

### DIFF
--- a/{{cookiecutter.repository_name}}/.globality/build.json
+++ b/{{cookiecutter.repository_name}}/.globality/build.json
@@ -11,6 +11,7 @@
       }
     ],
     "name": "{{ cookiecutter.repository_name }}",
+    "import-name": "{{ cookiecutter.package_name }}",
     "service_command": "serve",
     "service_port": 8080,
     "update_commands": [


### PR DESCRIPTION
Follow our terraform & github conventions by using the dash-syntax when referring to the repository and model names.